### PR TITLE
feat: add github pages deployment to build workfow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ "trunk" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -67,3 +70,24 @@ jobs:
           ctest --build-config Debug \
                 --test-dir ${{ env.build_output_dir }} \
                 --output-on-failure
+
+    - name: Upload doc files
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: ${{ env.build_output_dir }}/documentation/dirhtml
+
+  deploy:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
         path: ${{ env.build_output_dir }}/documentation/dirhtml
 
   deploy:
+    if: ${{ success() && github.event_name == 'push' && github.ref == 'trunk' }}
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
 
     env:
       LANG: en_US.UTF-8
+      build_output_dir: "${{ github.workspace }}/.build"
 
     strategy:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
@@ -44,13 +45,6 @@ jobs:
 
     - uses: flox/install-flox-action@v2
 
-    - name: Set reusable strings
-      # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
-      id: strings
-      shell: bash
-      run: |
-        echo "build-output-dir=${{ github.workspace }}/.build" >> "$GITHUB_OUTPUT"
-
     - name: Run Maud
       uses: flox/activate-action@v1
       with:
@@ -64,12 +58,12 @@ jobs:
     - name: Build
       uses: flox/activate-action@v1
       with:
-        command: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config Debug
+        command: cmake --build ${{ env.build_output_dir }} --config Debug
 
     - name: Test
       uses: flox/activate-action@v1
       with:
         command: >
           ctest --build-config Debug \
-                --test-dir ${{ steps.strings.outputs.build-output-dir }} \
+                --test-dir ${{ env.build_output_dir }} \
                 --output-on-failure


### PR DESCRIPTION
* use `env` for build dir for more compact code
* minimize permissions on workflows
* upload built docs as artifacts (downloadable in PRs)
* deploy built docs to github pages on `push` to `trunk`

Result: https://jacob.wujciak.de/maud/

The pages source has to be set to 'Github Actions Workflow' instead of 'Branch (classic)'. There are also additional settings for https and a custom url see [docs](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain)