### PR TITLE
fix(ci): Use proper context var in deploy conditional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
         path: ${{ env.build_output_dir }}/documentation/dirhtml
 
   deploy:
-    #if: ${{ success() && github.event_name == 'push' && github.ref == 'trunk' }}
+    if: ${{ !cancelled && github.event_name == 'push' && github.ref_name == 'trunk' }}
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
`github.ref` is the fully formed ref `refs/head...` we want just the name.