### PR TITLE
Avoid iteration of ``env.temp_data``

### DIFF
--- a/cmake_modules/trike/trike/__init__.py
+++ b/cmake_modules/trike/trike/__init__.py
@@ -533,18 +533,17 @@ class PutDirective(SphinxDirective):
     def cpp(self):
         "Temporarily set the default domain/language to C++"
         stashed = {
-            key: val
-            for key, val in self.env.temp_data.items()
-            if key in {"default_domain", "highlight_language"}
+            key: self.env.temp_data[key]
+            for key in ("default_domain", "highlight_language")
+            if key in self.env.temp_data
         }
         self.env.temp_data["default_domain"] = self.env.domains["cpp"]
         self.env.temp_data["highlight_language"] = "cpp"
         try:
             yield
         finally:
-            for key in stashed.keys():
-                del self.env.temp_data[key]
-            self.env.temp_data.update(stashed)
+            for key, stashed_val in stashed.items():
+                self.env.temp_data[key] = stashed_val
 
     def get_directive(self) -> tuple[str, str]:
         """


### PR DESCRIPTION
We are looking to change ``temp_data`` from a ``dict`` to a better-typed object (c.f. https://github.com/sphinx-doc/sphinx/pull/13151). This change will be backward compatibile, but this repo is the only instance I have found of `temp_data.items()`, and currently `temp_data` is not really public API *de jure*. This PR ought to maintain the current behaviour, and is even slightly faster.

A